### PR TITLE
Add bower compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "DocEditable",
+  "version": "0.0.0",
+  "homepage": "https://github.com/Foliotek/DocEditable",
+  "authors": [
+    "Foliotek"
+  ],
+  "description": "Clean WYSIWYG editing in your browser.",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.1",
+    "codemirror": "~4.4.0",
+    "bootstrap": "~3.2.0"
+  }
+}


### PR DESCRIPTION
This PR adds bower compatibility to the project

Todo: Remove dependencies from `js` folder and reference their `bower_components` counterparts instead
